### PR TITLE
Workaround that displays CyLineUp views side-by-side in Cytoscape 3.4…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,20 +3,20 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<properties>
-		<cytoscape.api.version>3.1.0</cytoscape.api.version>
+		<cytoscape.api.version>3.4.0</cytoscape.api.version>
 	</properties>
 
 	<parent>
 		<groupId>org.cytoscape</groupId>
 		<artifactId>parent</artifactId>
-		<version>3.1.0</version>
+		<version>3.4.0</version>
 		<relativePath>../parent</relativePath>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>nl.bioinformatics.cylineup</groupId>
 	<artifactId>cylineup</artifactId>
-	<version>1.0.1</version>
+	<version>1.0.2</version>
 
 	<name>CyLineUp</name>
 	<description>Small multiples in Cytoscape</description>

--- a/src/main/java/nl/bioinformatics/cylineup/actions/CyLineUpImportAction.java
+++ b/src/main/java/nl/bioinformatics/cylineup/actions/CyLineUpImportAction.java
@@ -1,16 +1,17 @@
 package nl.bioinformatics.cylineup.actions;
 
 import java.awt.event.ActionEvent;
+import java.util.Set;
 
 import javax.swing.JOptionPane;
-
-import nl.bioinformatics.cylineup.CyLineUpReferences;
-import nl.bioinformatics.cylineup.models.SmallMultiple;
-import nl.bioinformatics.cylineup.tasks.ImportTask;
 
 import org.cytoscape.application.swing.AbstractCyAction;
 import org.cytoscape.view.model.CyNetworkView;
 import org.cytoscape.work.TaskIterator;
+
+import nl.bioinformatics.cylineup.CyLineUpReferences;
+import nl.bioinformatics.cylineup.models.SmallMultiple;
+import nl.bioinformatics.cylineup.tasks.ImportTask;
 
 public class CyLineUpImportAction extends AbstractCyAction {
 	
@@ -39,8 +40,10 @@ public class CyLineUpImportAction extends AbstractCyAction {
 			
 			// Delete network views, or do nothing
 			if(answer == JOptionPane.OK_OPTION) {
+				Set<CyNetworkView> viewSet = refs.networkViewManager.getNetworkViewSet();
+				
 				for(SmallMultiple sm : refs.smallMultiples) {
-					if(sm.getView() != null) {
+					if(sm.getView() != null && viewSet.contains(sm.getView())) {
 						refs.networkViewManager.destroyNetworkView(sm.getView());
 					}
 				}

--- a/src/main/java/nl/bioinformatics/cylineup/actions/CyLineUpUpdateAction.java
+++ b/src/main/java/nl/bioinformatics/cylineup/actions/CyLineUpUpdateAction.java
@@ -2,12 +2,11 @@ package nl.bioinformatics.cylineup.actions;
 
 import java.awt.event.ActionEvent;
 
-import nl.bioinformatics.cylineup.CyLineUpReferences;
-import nl.bioinformatics.cylineup.gui.SwingHelper;
-
 import org.cytoscape.application.swing.AbstractCyAction;
 import org.cytoscape.view.model.CyNetworkView;
 import org.cytoscape.view.presentation.property.BasicVisualLexicon;
+
+import nl.bioinformatics.cylineup.CyLineUpReferences;
 
 
 public class CyLineUpUpdateAction extends AbstractCyAction {
@@ -28,16 +27,15 @@ public class CyLineUpUpdateAction extends AbstractCyAction {
 		CyNetworkView networkView = refs.appManager.getCurrentNetworkView();
 		
 		// Loop over all network views to set the zoom and the panning
-		for(CyNetworkView nv : refs.networkViewManager.getNetworkViewSet()) {
-			if(!nv.equals(networkView)) {
-				nv.setVisualProperty(BasicVisualLexicon.NETWORK_SCALE_FACTOR, networkView.getVisualProperty(BasicVisualLexicon.NETWORK_SCALE_FACTOR));
-				nv.setVisualProperty(BasicVisualLexicon.NETWORK_CENTER_X_LOCATION, networkView.getVisualProperty(BasicVisualLexicon.NETWORK_CENTER_X_LOCATION));
-				nv.setVisualProperty(BasicVisualLexicon.NETWORK_CENTER_Y_LOCATION, networkView.getVisualProperty(BasicVisualLexicon.NETWORK_CENTER_Y_LOCATION));
+		if(networkView != null) {
+			for(CyNetworkView nv : refs.networkViewManager.getNetworkViewSet()) {
+				if(!nv.equals(networkView)) {
+					nv.setVisualProperty(BasicVisualLexicon.NETWORK_SCALE_FACTOR, networkView.getVisualProperty(BasicVisualLexicon.NETWORK_SCALE_FACTOR));
+					nv.setVisualProperty(BasicVisualLexicon.NETWORK_CENTER_X_LOCATION, networkView.getVisualProperty(BasicVisualLexicon.NETWORK_CENTER_X_LOCATION));
+					nv.setVisualProperty(BasicVisualLexicon.NETWORK_CENTER_Y_LOCATION, networkView.getVisualProperty(BasicVisualLexicon.NETWORK_CENTER_Y_LOCATION));
+				}
 			}
 		}
-		
-		// Arrange windows
-		SwingHelper.arrangeWindows(refs);
 		
 	}
 	

--- a/src/main/java/nl/bioinformatics/cylineup/gui/panels/CyLineUpPanel.java
+++ b/src/main/java/nl/bioinformatics/cylineup/gui/panels/CyLineUpPanel.java
@@ -28,7 +28,6 @@ import javax.swing.event.ChangeListener;
 import nl.bioinformatics.cylineup.CyLineUpReferences;
 import nl.bioinformatics.cylineup.gui.LayoutHelper;
 import nl.bioinformatics.cylineup.tasks.ExportWindowTask;
-import nl.bioinformatics.cylineup.tasks.PreviewTask;
 import nl.bioinformatics.cylineup.tasks.UpdateTask;
 import nl.bioinformatics.cylineup.visual.VisualSettings;
 
@@ -133,7 +132,7 @@ public class CyLineUpPanel extends JPanel implements CytoPanelComponent {
 		
 		/** Create layout **/
 		
-		layout.addRow(new JLabel("<html><h1>CyLineUp v1.0.1</h1></html>"));
+		layout.addRow(new JLabel("<html><h1>CyLineUp v1.0.2</h1></html>"));
 		layout.addRow(new JLabel("<html><b>DATA</b></html>"));
 		layout.addRow(new JLabel("<html><p>Start with opening the network to which you want to map your transcriptome data. Then press the button 'Import data' below to open your datafile and map columns to small multiples of the current network.</p></html>"));
 		layout.addRow(importBtn);

--- a/src/main/java/nl/bioinformatics/cylineup/gui/windows/DataWindow.java
+++ b/src/main/java/nl/bioinformatics/cylineup/gui/windows/DataWindow.java
@@ -17,6 +17,11 @@ import javax.swing.ListSelectionModel;
 import javax.swing.event.ListSelectionEvent;
 import javax.swing.event.ListSelectionListener;
 
+import org.cytoscape.work.FinishStatus;
+import org.cytoscape.work.ObservableTask;
+import org.cytoscape.work.TaskIterator;
+import org.cytoscape.work.TaskObserver;
+
 import nl.bioinformatics.cylineup.CyLineUpReferences;
 import nl.bioinformatics.cylineup.gui.ColumnItem;
 import nl.bioinformatics.cylineup.gui.JTableButtonMouseListener;
@@ -28,8 +33,6 @@ import nl.bioinformatics.cylineup.models.SMTableModel;
 import nl.bioinformatics.cylineup.models.SmallMultiple;
 import nl.bioinformatics.cylineup.models.TableRowTransferHandler;
 import nl.bioinformatics.cylineup.tasks.CreateTask;
-
-import org.cytoscape.work.TaskIterator;
 
 public class DataWindow extends JFrame {
 
@@ -210,7 +213,18 @@ public class DataWindow extends JFrame {
 			public void actionPerformed(ActionEvent arg0) {
 				
 				// Run creation task
-				refs.taskManager.execute(new TaskIterator(new CreateTask(tModel.smallMultiples, refs)));
+				CreateTask task = new CreateTask(tModel.smallMultiples, refs);
+				refs.taskManager.execute(new TaskIterator(task), new TaskObserver() {
+					@Override
+					public void taskFinished(ObservableTask task) {
+					}
+					@Override
+					public void allFinished(FinishStatus status) {
+						if(status.getType() == FinishStatus.Type.SUCCEEDED) {
+							SwingHelper.arrangeWindows(refs);
+						}
+					}
+				});
 				
 				// Close current window
 				dispose();

--- a/src/main/java/nl/bioinformatics/cylineup/tasks/CreateTask.java
+++ b/src/main/java/nl/bioinformatics/cylineup/tasks/CreateTask.java
@@ -1,16 +1,19 @@
 package nl.bioinformatics.cylineup.tasks;
 
+import java.util.ArrayList;
 import java.util.List;
+
+import org.cytoscape.view.model.CyNetworkView;
+import org.cytoscape.work.AbstractTask;
+import org.cytoscape.work.ObservableTask;
+import org.cytoscape.work.TaskMonitor;
 
 import nl.bioinformatics.cylineup.CyLineUpReferences;
 import nl.bioinformatics.cylineup.NetworkHelper;
 import nl.bioinformatics.cylineup.models.SmallMultiple;
 import nl.bioinformatics.cylineup.visual.VisualHelper;
 
-import org.cytoscape.work.AbstractTask;
-import org.cytoscape.work.TaskMonitor;
-
-public class CreateTask extends AbstractTask {
+public class CreateTask extends AbstractTask implements ObservableTask {
 
 	public CyLineUpReferences refs;
 	
@@ -47,6 +50,17 @@ public class CreateTask extends AbstractTask {
 		// Done
 		taskMonitor.setProgress(1.0);
 		
+	}
+
+	@Override
+	public Object getResults(Class type) {
+		
+		List<CyNetworkView> views = new ArrayList<CyNetworkView>();
+		for(SmallMultiple sm : refs.smallMultiples) {
+			views.add(sm.getView());
+		}
+		
+		return views;
 	}
 
 }

--- a/src/main/java/nl/bioinformatics/cylineup/visual/VisualHelper.java
+++ b/src/main/java/nl/bioinformatics/cylineup/visual/VisualHelper.java
@@ -1,10 +1,8 @@
 package nl.bioinformatics.cylineup.visual;
 
 import java.awt.Color;
-
-import nl.bioinformatics.cylineup.CyLineUpReferences;
-import nl.bioinformatics.cylineup.gui.SwingHelper;
-import nl.bioinformatics.cylineup.models.SmallMultiple;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.cytoscape.model.CyEdge;
 import org.cytoscape.model.CyNode;
@@ -13,6 +11,9 @@ import org.cytoscape.model.CyTable;
 import org.cytoscape.view.model.CyNetworkView;
 import org.cytoscape.view.model.View;
 import org.cytoscape.view.presentation.property.BasicVisualLexicon;
+
+import nl.bioinformatics.cylineup.CyLineUpReferences;
+import nl.bioinformatics.cylineup.models.SmallMultiple;
 
 public class VisualHelper {
 	
@@ -55,9 +56,11 @@ public class VisualHelper {
 			CyNetworkView view = sm.getView();
 			
 			// Set zoom and panning
-			view.setVisualProperty(BasicVisualLexicon.NETWORK_SCALE_FACTOR, networkView.getVisualProperty(BasicVisualLexicon.NETWORK_SCALE_FACTOR));
-			view.setVisualProperty(BasicVisualLexicon.NETWORK_CENTER_X_LOCATION, networkView.getVisualProperty(BasicVisualLexicon.NETWORK_CENTER_X_LOCATION));
-			view.setVisualProperty(BasicVisualLexicon.NETWORK_CENTER_Y_LOCATION, networkView.getVisualProperty(BasicVisualLexicon.NETWORK_CENTER_Y_LOCATION));
+			if(networkView != null) {
+				view.setVisualProperty(BasicVisualLexicon.NETWORK_SCALE_FACTOR, networkView.getVisualProperty(BasicVisualLexicon.NETWORK_SCALE_FACTOR));
+				view.setVisualProperty(BasicVisualLexicon.NETWORK_CENTER_X_LOCATION, networkView.getVisualProperty(BasicVisualLexicon.NETWORK_CENTER_X_LOCATION));
+				view.setVisualProperty(BasicVisualLexicon.NETWORK_CENTER_Y_LOCATION, networkView.getVisualProperty(BasicVisualLexicon.NETWORK_CENTER_Y_LOCATION));
+			}
 			
 			// Get table
 			CyTable table = view.getModel().getDefaultNodeTable();
@@ -177,14 +180,19 @@ public class VisualHelper {
 			
 		}
 		
-		// Arrange windows
-		SwingHelper.arrangeWindows(refs);
-		
 		// Update views
+		List<CyNetworkView> views = new ArrayList<CyNetworkView>();
+		
 		for(SmallMultiple sm : refs.smallMultiples) {
 			// Fit networks in windows
 			if(fit) { sm.getView().fitContent(); }
 			sm.getView().updateView();
+			views.add(sm.getView());
+		}
+		
+		// Select views
+		if (!views.isEmpty()) {
+			refs.appManager.setSelectedNetworkViews(views);
 		}
 		
 	}


### PR DESCRIPTION
Hi, CyLineUp authors:

Cytoscape 3.4 no longer renders network views in JInternalFrames, so the views generated by CyLineUp are not displayed in a grid automatically as in version 3.3.
However, I found a workaround that can make CyLineUp work almost the same way in Cytoscape 3.4, without the need for you to change your tutorial.
Basically, I had to:

**1.** Ask the CyApplicatioManager to select the new views:

``` java
applicationManager.setSelectedNetworkViews(views);
```

**2.** Use an AWT Robot to generate Key-Press events that first switch Cytoscape to Grid Mode (G) and then to View Mode (V), so the selected views are visualized/compared:

``` java
Robot robot = new Robot();
// Simulate key press for Grid Mode
robot.keyPress(KeyEvent.VK_G);
robot.keyRelease(KeyEvent.VK_G);
// Simulate key press for View Mode
robot.keyPress(KeyEvent.VK_V);
robot.keyRelease(KeyEvent.VK_V);
```

There are other minor changes, mostly NullPointerException fixes, but these are the major ones.

As a Cytoscape developer, I apologize for the trouble but we expect the UI changes in Cytoscape 3.4 will bring many advantages to users.
Please let me know if you need any help or have any questions.

Thanks,
Christian Lopes
